### PR TITLE
Improve test layout

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,5 +83,13 @@ exclude_lines = [
   "if TYPE_CHECKING:",
 ]
 
+[tool.ruff.lint.extend-per-file-ignores]
+"**/tests/*" = ["INP001"]
+
 [tool.ruff.lint.flake8-type-checking]
 runtime-evaluated-base-classes = ["pydantic.BaseModel"]
+
+[tool.pytest.ini_options]
+addopts = [
+    "--import-mode=importlib",
+]


### PR DESCRIPTION
Use importlib mode of pytest.
Remove `__init__.py` in tests.